### PR TITLE
chore: env.d.ts の import 後に空行を追加 (biome 2.4.13 対応)

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
+
   const component: DefineComponent<object, object, unknown>
   export default component
 }


### PR DESCRIPTION
## Summary
- biome 2.4.13 で `assist/source/organizeImports` が厳格化され、`src/env.d.ts` の `import type` 行の後に空行が必要になった
- dependabot PR #44 (@biomejs/biome 2.4.13) のマージブロッカー

## Test plan
- [x] `npx @biomejs/biome check src/env.d.ts` が pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)