### PR TITLE
Bump version to v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.1] - 2026-05-02
+
+### Dependencies
+
+- **marked** 17.0.6 → 18.0.1（block token / GFM table の改行処理 fix）
+- **vite** 8.0.8 → 8.0.10
+- **@biomejs/biome** 2.4.11 → 2.4.13（`assist/source/organizeImports` 厳格化に伴い `src/env.d.ts` を整形）
+- **vue-tsc** 3.2.6 → 3.2.7
+- **@codemirror/view** 6.41.0 → 6.41.1（codemirror group）
+- **tokio** 1.51.1 → 1.52.1
+- **uuid** (cargo) 1.23.0 → 1.23.1
+- **actions/setup-node** 6.3.0 → 6.4.0
+
 ## [0.6.0] - 2026-04-25
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.1] - 2026-05-02
 
+### Security
+
+- **marked** 17.0.6 → 18.0.3（GHSA: tokenizer 無限再帰による OOM DoS / high severity）
+
 ### Dependencies
 
-- **marked** 17.0.6 → 18.0.1（block token / GFM table の改行処理 fix）
+
 - **vite** 8.0.8 → 8.0.10
 - **@biomejs/biome** 2.4.11 → 2.4.13（`assist/source/organizeImports` 厳格化に伴い `src/env.d.ts` を整形）
 - **vue-tsc** 3.2.6 → 3.2.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pike",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pike",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
@@ -35,7 +35,7 @@
         "@xterm/xterm": "^6.0.0",
         "dompurify": "^3.4.1",
         "lucide-vue-next": "^1.0.0",
-        "marked": "^18.0.1",
+        "marked": "^18.0.3",
         "material-file-icons": "^2.4.0",
         "mermaid": "^11.14.0",
         "pinia": "^3.0.4",
@@ -2859,9 +2859,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.1.tgz",
-      "integrity": "sha512-IILJE4Aap/KIGu4ZRCzQcYMxkhumblXnbqfQe+HAD4f982wrRAsJEGKGM653yAioS6g3Yq3yOhjrUebcrtOgRA==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pike",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Lightweight AI-coding-focused development environment built with Tauri v2",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@xterm/xterm": "^6.0.0",
     "dompurify": "^3.4.1",
     "lucide-vue-next": "^1.0.0",
-    "marked": "^18.0.1",
+    "marked": "^18.0.3",
     "material-file-icons": "^2.4.0",
     "mermaid": "^11.14.0",
     "pinia": "^3.0.4",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "pike"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pike"
-version = "0.6.0"
+version = "0.6.1"
 description = "Lightweight AI-coding-focused development environment"
 authors = ["Kan Fushihara <kan.fushihara@gmail.com>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Pike",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.pike.dev",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- v0.6.1 リリース。dependabot による依存更新のみ
- `src-tauri/tauri.conf.json` / `package.json` / `src-tauri/Cargo.toml` / `Cargo.lock` / `CHANGELOG.md` を 0.6.1 に更新

## Dependencies
- marked 17.0.6 → 18.0.1
- vite 8.0.8 → 8.0.10
- @biomejs/biome 2.4.11 → 2.4.13
- vue-tsc 3.2.6 → 3.2.7
- @codemirror/view 6.41.0 → 6.41.1
- tokio 1.51.1 → 1.52.1
- uuid (cargo) 1.23.0 → 1.23.1
- actions/setup-node 6.3.0 → 6.4.0

## Test plan
- [x] `cargo check` で Cargo.lock が新バージョンに同期
- [ ] CI が pass
- [ ] マージ後 `git tag v0.6.1 && git push origin v0.6.1` で Release workflow を起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)