### PR TITLE
feat(git): コミットリストに右クリックコンテキストメニュー

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -340,6 +340,56 @@ pub async fn git_checkout(
     .map_err(|e| e.to_string())?
 }
 
+fn validate_ref_name(name: &str) -> Result<(), String> {
+    // 最低限のフラグ injection 対策と git のリファレンス命名規約に沿った検証
+    if name.is_empty() {
+        return Err("branch name is empty".to_string());
+    }
+    if name.starts_with('-') {
+        return Err("branch name cannot start with '-'".to_string());
+    }
+    if name
+        .chars()
+        .any(|c| c.is_control() || matches!(c, ' ' | '~' | '^' | ':' | '?' | '*' | '[' | '\\'))
+    {
+        return Err("branch name contains invalid characters".to_string());
+    }
+    if name.contains("..") || name.contains("@{") {
+        return Err("branch name contains invalid sequence".to_string());
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_create_branch(
+    root: String,
+    shell: ShellConfig,
+    name: String,
+    start_point: String,
+) -> Result<(), String> {
+    validate_ref_name(&name)?;
+    validate_ref_name(&start_point)?;
+    tokio::task::spawn_blocking(move || {
+        run_git(&shell, &root, &["branch", &name, &start_point])?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn git_remote_url(
+    root: String,
+    shell: ShellConfig,
+) -> Result<Option<String>, String> {
+    let output = tokio::task::spawn_blocking(move || {
+        run_git(&shell, &root, &["remote", "get-url", "origin"])
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+    Ok(output.ok().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()))
+}
+
 #[tauri::command]
 pub async fn git_fetch(root: String, shell: ShellConfig) -> Result<(), String> {
     tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -705,6 +705,8 @@ pub fn run() {
             git::git_commit,
             git::git_branch_list,
             git::git_checkout,
+            git::git_create_branch,
+            git::git_remote_url,
             git::git_fetch,
             git::git_push,
             git::git_pull,

--- a/src/components/panels/GitPanel.vue
+++ b/src/components/panels/GitPanel.vue
@@ -1,12 +1,22 @@
 <script setup lang="ts">
 import { ArrowUp, ChevronDown, ChevronRight, Minus, Plus, Undo2 } from 'lucide-vue-next'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
-import { confirmDialog } from '../../composables/useConfirmDialog'
+import { confirmDialog, infoDialog, promptDialog } from '../../composables/useConfirmDialog'
 import { useI18n } from '../../i18n'
 import { fileIconSvg } from '../../lib/fileIcons'
 import { buildGraph, DOT_RADIUS, LANE_WIDTH, ROW_HEIGHT } from '../../lib/gitGraph'
+import { buildCommitLink } from '../../lib/gitRemote'
 import { gitStatusColor, relativeDate } from '../../lib/paths'
-import { fsDelete, gitDiff, gitDiffCommit, gitShowFile, gitShowFiles } from '../../lib/tauri'
+import {
+  fsDelete,
+  gitCreateBranch,
+  gitDiff,
+  gitDiffCommit,
+  gitRemoteUrl,
+  gitShowFile,
+  gitShowFiles,
+  openUrlWithConfirm,
+} from '../../lib/tauri'
 import { useGitStore } from '../../stores/git'
 import { useProjectStore } from '../../stores/project'
 import { useSidebarStore } from '../../stores/sidebar'
@@ -151,6 +161,82 @@ function onCommitLeave() {
   hoveredCommit.value = null
 }
 
+const remoteUrl = ref<string | null>(null)
+const commitLink = computed(() =>
+  commitCtx.value ? buildCommitLink(remoteUrl.value, commitCtx.value.entry.hash) : null,
+)
+
+async function loadRemoteUrl() {
+  const project = projectStore.currentProject
+  if (!project) {
+    remoteUrl.value = null
+    return
+  }
+  try {
+    remoteUrl.value = await gitRemoteUrl(project.root, project.shell)
+  } catch {
+    remoteUrl.value = null
+  }
+}
+
+const commitCtx = ref<{ x: number; y: number; entry: GitLogEntry } | null>(null)
+
+function onCommitContext(e: MouseEvent, entry: GitLogEntry) {
+  e.preventDefault()
+  e.stopPropagation()
+  // 同じメニューを開きっぱなしで右クリックされた場合に古い listener が残らないよう先に外す
+  window.removeEventListener('mousedown', closeCommitCtx)
+  commitCtx.value = { x: e.clientX, y: e.clientY, entry }
+  nextTick(() => {
+    window.addEventListener('mousedown', closeCommitCtx, { once: true })
+  })
+}
+
+function closeCommitCtx() {
+  commitCtx.value = null
+  window.removeEventListener('mousedown', closeCommitCtx)
+}
+
+async function ctxCopyHash() {
+  if (!commitCtx.value) return
+  await navigator.clipboard.writeText(commitCtx.value.entry.hash)
+  closeCommitCtx()
+}
+
+async function ctxCopyShortHash() {
+  if (!commitCtx.value) return
+  await navigator.clipboard.writeText(commitCtx.value.entry.hash.slice(0, 7))
+  closeCommitCtx()
+}
+
+async function ctxCopyMessage() {
+  if (!commitCtx.value) return
+  await navigator.clipboard.writeText(commitCtx.value.entry.message)
+  closeCommitCtx()
+}
+
+async function ctxCreateBranch() {
+  if (!commitCtx.value) return
+  const entry = commitCtx.value.entry
+  closeCommitCtx()
+  const project = projectStore.currentProject
+  if (!project) return
+  const name = await promptDialog(t('git.createBranchPrompt', { hash: entry.hash.slice(0, 7) }), '', 'feature/...')
+  if (!name) return
+  try {
+    await gitCreateBranch(project.root, project.shell, name.trim(), entry.hash)
+    await gitStore.refreshLog()
+  } catch (e) {
+    await infoDialog(t('git.createBranchFailed', { error: String(e) }))
+  }
+}
+
+async function ctxOpenOnRemote() {
+  const link = commitLink.value
+  closeCommitCtx()
+  if (link) await openUrlWithConfirm(link.url)
+}
+
 // File context menu (shared between CHANGES and COMMITS)
 const fileCtx = ref<{
   x: number
@@ -164,6 +250,7 @@ const fileCtx = ref<{
 function onFileContext(e: MouseEvent, path: string, opts: { hash?: string; staged?: boolean; untracked?: boolean }) {
   e.preventDefault()
   e.stopPropagation()
+  window.removeEventListener('mousedown', closeFileCtx)
   fileCtx.value = { x: e.clientX, y: e.clientY, path, ...opts }
   nextTick(() => {
     window.addEventListener('mousedown', closeFileCtx, { once: true })
@@ -172,6 +259,7 @@ function onFileContext(e: MouseEvent, path: string, opts: { hash?: string; stage
 
 function closeFileCtx() {
   fileCtx.value = null
+  window.removeEventListener('mousedown', closeFileCtx)
 }
 
 async function ctxOpenDiff() {
@@ -221,11 +309,15 @@ watch(
   () => {
     expandedCommits.value.clear()
     commitFiles.value = {}
+    loadRemoteUrl()
     refreshIfActive()
   },
 )
 
-onMounted(refreshIfActive)
+onMounted(() => {
+  loadRemoteUrl()
+  refreshIfActive()
+})
 onUnmounted(() => {
   if (tooltipTimer) clearTimeout(tooltipTimer)
 })
@@ -329,6 +421,7 @@ onUnmounted(() => {
               class="log-item"
               :class="{ unpushed: unpushedHashes.has(entry.hash) }"
               @click="toggleCommitExpand(entry.hash)"
+              @contextmenu="onCommitContext($event, entry)"
               @mouseenter="onCommitEnter(entry, $event)"
               @mouseleave="onCommitLeave"
             >
@@ -364,6 +457,7 @@ onUnmounted(() => {
               class="graph-row"
               :class="{ unpushed: unpushedHashes.has(row.hash) }"
               @click="toggleCommitExpand(row.hash)"
+              @contextmenu="gitStore.logEntries[i] && onCommitContext($event, gitStore.logEntries[i])"
               @mouseenter="gitStore.logEntries[i] && onCommitEnter(gitStore.logEntries[i], $event)"
               @mouseleave="onCommitLeave"
             >
@@ -450,6 +544,26 @@ onUnmounted(() => {
       >
         <button @click="ctxOpenDiff">{{ t('git.openDiff') }}</button>
         <button @click="ctxOpenFile">{{ t('git.openFile') }}</button>
+      </div>
+    </Teleport>
+
+    <!-- Commit context menu -->
+    <Teleport to="body">
+      <div
+        v-if="commitCtx"
+        class="commit-file-ctx"
+        :style="{ left: commitCtx.x + 'px', top: commitCtx.y + 'px' }"
+        @mousedown.stop
+      >
+        <button @click="ctxCopyHash">{{ t('git.copyHash') }}</button>
+        <button @click="ctxCopyShortHash">{{ t('git.copyShortHash') }}</button>
+        <button @click="ctxCopyMessage">{{ t('git.copyMessage') }}</button>
+        <div class="ctx-separator" />
+        <button @click="ctxCreateBranch">{{ t('git.createBranchFromCommit') }}</button>
+        <template v-if="commitLink">
+          <div class="ctx-separator" />
+          <button @click="ctxOpenOnRemote">{{ t('git.openOnProvider', { provider: commitLink.label }) }}</button>
+        </template>
       </div>
     </Teleport>
   </div>
@@ -837,5 +951,11 @@ onUnmounted(() => {
 .commit-file-ctx button:hover {
   background: var(--accent);
   color: var(--text-active);
+}
+
+.commit-file-ctx .ctx-separator {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
 }
 </style>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -173,6 +173,13 @@ export default {
   'git.graphView': 'Graph',
   'git.switchBranch': 'Switch branch...',
   'git.noBranches': 'No matching branches',
+  'git.copyHash': 'Copy commit hash',
+  'git.copyShortHash': 'Copy short hash',
+  'git.copyMessage': 'Copy commit message',
+  'git.createBranchFromCommit': 'Create branch from this commit...',
+  'git.createBranchPrompt': 'New branch name from {hash}:',
+  'git.createBranchFailed': 'Failed to create branch: {error}',
+  'git.openOnProvider': 'Open on {provider}',
 
   // Docker Panel
   'docker.notReachable': 'Docker not reachable',

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -174,6 +174,13 @@ export default {
   'git.graphView': 'グラフ',
   'git.switchBranch': 'ブランチを切替...',
   'git.noBranches': 'ブランチが見つかりません',
+  'git.copyHash': 'コミットハッシュをコピー',
+  'git.copyShortHash': '短いハッシュをコピー',
+  'git.copyMessage': 'コミットメッセージをコピー',
+  'git.createBranchFromCommit': 'このコミットからブランチを作成...',
+  'git.createBranchPrompt': '{hash} から作成する新しいブランチ名:',
+  'git.createBranchFailed': 'ブランチ作成に失敗しました: {error}',
+  'git.openOnProvider': '{provider} で開く',
 
   // Docker Panel
   'docker.notReachable': 'Docker に接続できません',

--- a/src/lib/gitRemote.ts
+++ b/src/lib/gitRemote.ts
@@ -1,0 +1,77 @@
+// origin URL から既知のホスティングサービスを検出し、コミットページの URL を組み立てる。
+// 未知のホストは null を返し、UI 側で「リモートで開く」メニューを非表示にする。
+
+type Provider = 'github' | 'gitlab' | 'bitbucket' | 'codeberg'
+
+const PROVIDERS: Record<string, { provider: Provider; label: string }> = {
+  'github.com': { provider: 'github', label: 'GitHub' },
+  'gitlab.com': { provider: 'gitlab', label: 'GitLab' },
+  'bitbucket.org': { provider: 'bitbucket', label: 'Bitbucket' },
+  'codeberg.org': { provider: 'codeberg', label: 'Codeberg' },
+}
+
+interface ParsedRemote {
+  provider: Provider
+  label: string
+  host: string
+  owner: string
+  repo: string
+}
+
+function parseRemote(url: string | null): ParsedRemote | null {
+  if (!url) return null
+  let host: string
+  let path: string
+
+  // SCP 形式: git@host:owner/repo(.git)
+  const scp = url.match(/^[\w.-]+@([^:]+):(.+?)(?:\.git)?\/?$/)
+  if (scp) {
+    host = scp[1]
+    path = scp[2]
+  } else {
+    const normalized = url.trim()
+    if (!/^[a-z]+:\/\//i.test(normalized)) return null
+    try {
+      const u = new URL(normalized)
+      host = u.host
+      path = u.pathname.replace(/^\//, '').replace(/\.git\/?$/, '')
+    } catch {
+      return null
+    }
+  }
+
+  const meta = PROVIDERS[host]
+  if (!meta) return null
+
+  // owner/repo 形式想定 (GitLab はグループ多段あり)
+  const segments = path.split('/').filter(Boolean)
+  if (segments.length < 2) return null
+  const repo = segments.pop() as string
+  const owner = segments.join('/')
+  return { ...meta, host, owner, repo: repo.replace(/\.git$/, '') }
+}
+
+export interface CommitLink {
+  url: string
+  label: string
+}
+
+export function buildCommitLink(remoteUrl: string | null, hash: string): CommitLink | null {
+  const parsed = parseRemote(remoteUrl)
+  if (!parsed) return null
+  const base = `https://${parsed.host}/${parsed.owner}/${parsed.repo}`
+  let url: string
+  switch (parsed.provider) {
+    case 'github':
+    case 'codeberg':
+      url = `${base}/commit/${hash}`
+      break
+    case 'gitlab':
+      url = `${base}/-/commit/${hash}`
+      break
+    case 'bitbucket':
+      url = `${base}/commits/${hash}`
+      break
+  }
+  return { url, label: parsed.label }
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -199,6 +199,14 @@ export async function gitCheckout(root: string, shell: ShellType, branch: string
   return invoke('git_checkout', { root, shell, branch })
 }
 
+export async function gitCreateBranch(root: string, shell: ShellType, name: string, startPoint: string): Promise<void> {
+  return invoke('git_create_branch', { root, shell, name, startPoint })
+}
+
+export async function gitRemoteUrl(root: string, shell: ShellType): Promise<string | null> {
+  return invoke<string | null>('git_remote_url', { root, shell })
+}
+
 export async function gitFetch(root: string, shell: ShellType): Promise<void> {
   return invoke('git_fetch', { root, shell })
 }


### PR DESCRIPTION
## Summary
- Git パネルのコミットリスト/グラフを右クリックでメニュー表示
  - コミットハッシュをコピー / 短いハッシュ (7文字) をコピー
  - コミットメッセージをコピー
  - このコミットからブランチを作成... (promptDialog でブランチ名入力)
  - {Provider} で開く — origin URL から **GitHub / GitLab / Bitbucket / Codeberg** を判定し、未対応 origin では非表示
- 副次対応: 既存 \`fileCtx\` も含めた context menu の listener race（連続右クリックで listener が累積する潜在バグ）を修正

## 実装メモ
- Rust: \`git_create_branch\`, \`git_remote_url\` を追加。\`validate_ref_name\` でフラグ injection / 不正文字 / \`..\` / \`@{\` を弾く。\`name\` と \`start_point\` 両方に適用
- \`src/lib/gitRemote.ts\`: SCP 形式と HTTPS/SSH URL 両方をパース。\`buildCommitLink(remoteUrl, hash) → { url, label } | null\` の単一エントリポイントに集約

## Test plan
- [x] \`cargo clippy -- -D warnings\` pass
- [x] \`npm run lint\` pass
- [x] \`npx vue-tsc --noEmit\` pass
- [x] List ビュー / Graph ビュー両方で右クリックメニュー動作
- [x] origin が GitHub の場合「GitHub で開く」項目が表示される
- [x] ブランチ作成 → ログがリフレッシュされる
- [ ] (任意) origin なしのプロジェクトで「リモートで開く」項目が出ないこと
- [ ] (任意) 不正ブランチ名 (\`-foo\`, \`foo..bar\` 等) でエラーダイアログが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)